### PR TITLE
DEVOPS-4855 Update release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
Not sure this will fix the failing github release workflow, but the current github action from hashicorp says not to use it anymore: https://github.com/hashicorp/ghaction-import-gpg

Updating the workflow to the one they point to.


# Reviewer Instructions

* Ensure that the plan filename matches from the output of the plan and the deployment instructions below.
* That only the expected changes will occur.  No unintentional resources will be changed.

# Deployment Instructions
TFE
