### PR TITLE
DEVOPS-4855 Add target resource. fix errors checking for new targets

### DIFF
--- a/snyk/api/projects.go
+++ b/snyk/api/projects.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 )
 
 type OwnerDetails struct {
@@ -21,22 +20,6 @@ type Projects struct {
 	Owner  OwnerDetails
 }
 
-type TargetImport struct {
-	Target Target `json:"target"`
-}
-
-type Target struct {
-	Owner  string `json:"owner"`
-	Name   string `json:"name"`
-	Branch string `json:"branch"`
-	Id     string `json:"id,omitempty"`
-}
-
-type ImportStatus struct {
-	ID     string `json:"id"`
-	Status string `json:"status"`
-}
-
 func GetProjectById(so SnykOptions, orgId string, intType string) (*Projects, error) {
 	path := fmt.Sprintf("/org/%s/project/%s", orgId, intType)
 
@@ -49,7 +32,6 @@ func GetProjectById(so SnykOptions, orgId string, intType string) (*Projects, er
 	defer res.Body.Close()
 	var proj Projects
 	json.NewDecoder(res.Body).Decode(&proj)
-	log.Println("proj_name=", proj.Name)
 	project := &Projects{
 		Id:     proj.Id,
 		Name:   proj.Name,
@@ -75,8 +57,6 @@ func GetProjectOwner(so SnykOptions, orgId string, intType string) (*OwnerDetail
 	var proj Projects
 	json.NewDecoder(res.Body).Decode(&proj)
 
-	log.Println("proj= ", proj.Owner.Name)
-
 	project := &OwnerDetails{
 		Id:   proj.Owner.Id,
 		Name: proj.Owner.Name,
@@ -88,7 +68,12 @@ func GetProjectOwner(so SnykOptions, orgId string, intType string) (*OwnerDetail
 
 func GetAllProjects(so SnykOptions, orgId string) ([]Projects, error) {
 	path := fmt.Sprintf("/org/%s/projects", orgId)
+
 	res, err := clientDo(so, "GET", path, nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	defer res.Body.Close()
 
@@ -107,12 +92,17 @@ func GetAllProjects(so SnykOptions, orgId string) ([]Projects, error) {
 
 func GetProjectByName(so SnykOptions, orgId string, name string) (*Projects, error) {
 	projects, err := GetAllProjects(so, orgId)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	for _, project := range projects {
-		if project.Name == name {
+		if strings.Contains(project.Name, name) {
 			return &project, nil
 		}
 	}
@@ -151,80 +141,4 @@ func UpdateProject(so SnykOptions, id string, orgId string, integration string, 
 		return nil, err
 	}
 	return projects, nil
-}
-
-func ImportProject(so SnykOptions, orgId string, integration string, repository_owner string, repository_name string, branch string) (*Target, error) {
-	t := TargetImport{
-		Target{
-			Owner:  repository_owner,
-			Name:   repository_name,
-			Branch: branch,
-		},
-	}
-
-	path := fmt.Sprintf("/org/%s/integrations/%s/import", orgId, integration)
-	body, _ := json.Marshal(t)
-	res, err := clientDo(so, "POST", path, body)
-
-	if err != nil {
-		return nil, err
-	}
-
-	//get the import job url so we can check the status
-	jobUrl := fmt.Sprintf("%v", res.Header["Location"])
-	jobUrl = strings.Trim(jobUrl, "]")
-	jobId := strings.Split(jobUrl, "import/")
-
-	defer res.Body.Close()
-
-	//this needs to be fixed.  it only works on the repository root
-	full_name := repository_owner + "/" + repository_name
-
-	//check the API to see if the project imported
-	imports, err := getImportStatus(so, orgId, integration, jobId[1])
-
-	if err != nil {
-		return nil, err
-	}
-
-	//once we get a successful import, look up the project ID so we can return it in our struct
-	if imports == true {
-		projects, err := GetProjectByName(so, orgId, full_name)
-		if err != nil {
-		}
-		returnData := &Target{
-			Id:     projects.Id,
-			Name:   projects.Name,
-			Branch: projects.Branch,
-		}
-
-		return returnData, nil
-
-	}
-
-	return nil, err
-
-}
-
-func getImportStatus(so SnykOptions, orgId string, integration string, jobId string) (bool, error) {
-	path := fmt.Sprintf("/org/%s/integrations/%s/import/%s", orgId, integration, jobId)
-
-	//check api every 10 seconds, 20 times to get success message on porject import
-	for i := 0; i < 20; i++ {
-		res, err := clientDo(so, "GET", path, nil)
-
-		if err != nil {
-
-			return false, err
-		}
-
-		var stat ImportStatus
-		json.NewDecoder(res.Body).Decode(&stat)
-		if stat.Status == "complete" {
-			return true, nil
-		}
-		time.Sleep(10 * time.Second)
-
-	}
-	return false, nil
 }

--- a/snyk/api/targets.go
+++ b/snyk/api/targets.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type TargetImport struct {
+	Target Target `json:"target"`
+}
+
+type Target struct {
+	Owner  string `json:"owner"`
+	Name   string `json:"name"`
+	Branch string `json:"branch"`
+	Id     string `json:"id,omitempty"`
+}
+
+type ImportStatus struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func ImportProject(so SnykOptions, orgId string, integration string, repository_owner string, repository_name string, branch string) (*Target, error) {
+	t := TargetImport{
+		Target{
+			Owner:  repository_owner,
+			Name:   repository_name,
+			Branch: branch,
+		},
+	}
+
+	path := fmt.Sprintf("/org/%s/integrations/%s/import", orgId, integration)
+	body, _ := json.Marshal(t)
+	res, err := clientDo(so, "POST", path, body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	//get the import job url so we can check the status
+	jobUrl := fmt.Sprintf("%v", res.Header["Location"])
+	jobUrl = strings.Trim(jobUrl, "]")
+	jobId := strings.Split(jobUrl, "import/")
+
+	defer res.Body.Close()
+
+	//this needs to be fixed.  it only works on the repository root
+	full_name := repository_owner + "/" + repository_name + ":"
+
+	//check the API to see if the project imported
+	imports, err := getImportStatus(so, orgId, integration, jobId[1])
+
+	if err != nil {
+		return nil, err
+	}
+
+	//once we get a successful import, look up the project ID so we can return it in our struct
+	if imports == true {
+		projects, err := GetProjectByName(so, orgId, full_name)
+		if err != nil {
+		}
+		returnData := &Target{
+			Id:     projects.Id,
+			Name:   projects.Name,
+			Branch: projects.Branch,
+		}
+		return returnData, nil
+
+	}
+
+	return nil, err
+
+}
+
+func getImportStatus(so SnykOptions, orgId string, integration string, jobId string) (bool, error) {
+	path := fmt.Sprintf("/org/%s/integrations/%s/import/%s", orgId, integration, jobId)
+
+	//check api every 10 seconds, 20 times to get success message on porject import
+	for i := 0; i < 20; i++ {
+		res, err := clientDo(so, "GET", path, nil)
+
+		if err != nil {
+			return false, err
+		}
+
+		var stat ImportStatus
+		json.NewDecoder(res.Body).Decode(&stat)
+		if stat.Status == "complete" {
+			return true, nil
+		}
+		time.Sleep(10 * time.Second)
+
+	}
+	return false, nil
+}

--- a/snyk/provider.go
+++ b/snyk/provider.go
@@ -35,6 +35,7 @@ func Provider(version string) func() *schema.Provider {
 				"snyk_organization": resourceOrganization(),
 				"snyk_integration":  resourceIntegration(),
 				"snyk_project":      resourceProject(),
+				"snyk_target":       resourceProject(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"snyk_organization":  dataSourceOrganization(),

--- a/snyk/resource_target.go
+++ b/snyk/resource_target.go
@@ -1,0 +1,83 @@
+package snyk
+
+import (
+	"context"
+
+	"github.com/formstack/terraform-provider-snyk/snyk/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceTarget() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTargetCreate,
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"branch": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"integration": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"repository_owner": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"repository_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	var err error
+
+	so := m.(api.SnykOptions)
+
+	organization := d.Get("organization").(string)
+	repository_owner := d.Get("repository_owner").(string)
+	branch := d.Get("branch").(string)
+	repository_name := d.Get("repository_name").(string)
+	integration := d.Get("integration").(string)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var project *api.Target
+
+	project, err = api.ImportProject(so, organization, integration, repository_owner, repository_name, branch)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(project.Id)
+	d.Set("organization", organization)
+	d.Set("project_name", project.Name)
+	d.Set("branch", project.Branch)
+
+	//setCredentialState(project.TargetCredentials, d)
+
+	return diags
+}


### PR DESCRIPTION
I think at some point the Snyk API changed the responses it was giving when you check the API to see if your new resource had been created.

The provider had been checking for a project with a name like `formstack/server-playbooks`  which was working.  The provider is now crashing, and I'm seeing project names returned by the API that look like this:  `formstack/server-playbooks:requirements.txt`  

I've adjust the provider to check for `formstack/server-playbooks:` since we don't know the actual name of the dependency file in each repository.  This seems to be working.

I've moved some of the terraform resources from `Project` to `Target`.  Snyk terminolgy is confusing and their current API is limited in what resources it actually lets you manage, but this sets us up for a better transition if/when we are able to upgrade to API v3.


# Reviewer Instructions

* Ensure that the plan filename matches from the output of the plan and the deployment instructions below.
* That only the expected changes will occur.  No unintentional resources will be changed.

# Deployment Instructions
TFE
